### PR TITLE
Got rid of globalThis

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ const webpackBootstrapFunc = function () {// webpackBootstrap
   /******/ 	/* webpack/runtime/global */
   /******/ 	(() => {
   /******/ 		__webpack_require__.g = (function () {
-  /******/ 		if (Object.prototype.toString.call(globalThis) === '[object Object]') return globalThis
+  /******/ 		if (Object.prototype.toString.call(self) === '[object Object]') return self
   /******/ 			try {
   /******/ 				return this || new Function('return this')()
         /******/


### PR DESCRIPTION
### Changes
1. Replaced `globalThis` with `self` to get rid of `globalThis` in our bundle.

### Test
Tested locally:
```js
  /******/ 	/* webpack/runtime/global */
  /******/ 	(() => {
  /******/ 		__webpack_require__.g = (function () {
  /******/        console.log('!!! webpack/runtime/global');
  /******/        console.log('self === globalThis:', self === globalThis);
  /******/        console.log('this === globalThis:', this === globalThis);
  /******/ 		if (Object.prototype.toString.call(self) === '[object Object]') return self
```
Result:
![Screenshot 2022-09-21 092439](https://user-images.githubusercontent.com/30019338/191435817-a4e9c443-11bd-431c-b55f-5524122fd357.png)

### Notes
The `globalThis` changes made when migrating to `webpack@5`:  https://github.com/2gis/webworkify-webpack/commit/db0de750c4cb8bbb89c7a1fab000a25eaa54379d#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R64-R67
